### PR TITLE
feat: add signal handling serviceweaver config

### DIFF
--- a/cmd/boneless/main.go
+++ b/cmd/boneless/main.go
@@ -59,8 +59,8 @@ func init() {
 
 func main() {
 	flag.Usage = func() { fmt.Fprint(os.Stderr, usage) }
-
 	flag.Parse()
+
 	if len(flag.Args()) == 0 {
 		fmt.Fprint(os.Stderr, usage)
 		os.Exit(1)

--- a/internal/run.go
+++ b/internal/run.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -26,6 +27,7 @@ func findMainFile() (filePath string) {
 		panic(err)
 	}
 
+	// TODO: improve that to ensure that the file is the package main
 	_ = filepath.Walk(pwd, func(path string, info fs.FileInfo, _ error) error {
 		if !info.IsDir() {
 			if info.Name() == "main.go" {
@@ -40,6 +42,15 @@ func findMainFile() (filePath string) {
 
 func Start() {
 	mainFile := findMainFile()
+
+	// Set SERVICEWEAVER_CONFIG environment variable if not already set
+	if _, ok := os.LookupEnv("SERVICEWEAVER_CONFIG"); !ok {
+		err := os.Setenv("SERVICEWEAVER_CONFIG", "./weaver.toml")
+		if err != nil {
+			panic(fmt.Sprintf("failed to set env var SERVICEWEAVER_CONFIG: %s", err))
+		}
+	}
+
 	cmd := exec.Command("go", "run", mainFile)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -29,6 +29,7 @@ func ReadToml(componentName string) (qsConn string) {
 		panic(err)
 	}
 
+	// TODO: improve that same internal/run.go:46
 	weaverToml, err := ioutil.ReadFile(pwd + "/weaver.toml")
 	if err != nil {
 		panic(err)

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const Version = "v0.1.1"
+const Version = "v0.2.0"
 
 func ValidateLatestVersion() {
 	cmd := exec.Command("go", "list", "-m", "github.com/renanbastos93/boneless@latest")

--- a/templates/files/component.go.tpl
+++ b/templates/files/component.go.tpl
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ServiceWeaver/weaver"
+	_ "github.com/go-sql-driver/mysql"
 	"{{.Module}}/internal/{{.ComponentName}}/store"
 )
 


### PR DESCRIPTION
Added signal handling for graceful process termination and set the 
SERVICEWEAVER_CONFIG environment variable if not already set. 
The feature enhances the run method by incorporating signal handling 
for gracefully closing the process upon receiving SIGINT, SIGKILL, 
or SIGTERM signals. Additionally, a comment with a TODO was included 
for potential future improvements. Also, Set MySQL driver in template 
for database connections