### PR TITLE
🗑️ Add delete-app command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.20'
+
+    - name: Install dependencies
+      run: go mod tidy
+
+    - name: Run tests for delete command
+      run: go test ./internal/delete* -v

--- a/cmd/boneless/main.go
+++ b/cmd/boneless/main.go
@@ -20,6 +20,7 @@ Targets:
   migrate <app-name> <up|down>             Run migrations for an app
   create-app <app-name>                    Create a new app based on a template
   build-app <app-name>                     Build an app using Weaver and SQLC
+  delete-app <app-name>                    Delete an app created
   run                                      Run the project using Weaver
 
 Parameters:
@@ -37,6 +38,7 @@ Examples:
   boneless migrate my-app up
   boneless create-app my-app
   boneless build-app my-app
+  boneless delete-app my-app
   boneless run
 
 `
@@ -51,6 +53,7 @@ const (
 	cmdMigrate       = "migrate"
 	cmdCreateApp     = "create-app"
 	cmdBuildApp      = "build-app"
+	cmdDeleteApp     = "delete-app"
 	cmdRun           = "run"
 
 	DefaultComponentName = "app"
@@ -83,6 +86,8 @@ func main() {
 		internal.Build(flag.Arg(1), internal.KindComponent, "")
 		internal.SqlcGenerate(flag.Arg(1))
 		internal.WeaverGenerate()
+	case cmdDeleteApp:
+		internal.DeleteApp(flag.Arg(1))
 	case cmdBuild:
 		internal.SqlcGenerate()
 		internal.WeaverGenerate()

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -16,7 +16,7 @@ func DeleteApp(appName string) {
 	// Delete the app folder
 	err := os.RemoveAll(appFolderPath)
 	if err != nil {
-		panic(err)
+		panic("Error deleting app folder: "+ err.Error())
 	}
 
 	fmt.Printf("App deleted successfully: %s\n", appName)

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -16,7 +16,6 @@ func DeleteApp(appName string) {
 	// Delete the app folder
 	err := os.RemoveAll(appFolderPath)
 	if err != nil {
-		fmt.Println("Error deleting app folder: ", err)
 		panic(err)
 	}
 

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -6,7 +6,9 @@ import (
 )
 
 func DeleteApp(appName string) {
-	validateAppName(appName)
+	if isValid := isAppNameValid(appName); !isValid {
+		return
+	}
 
 	appFolderPath := getAppFolderPath(appName)
 	checkIfAppFolderExists(appFolderPath)
@@ -21,16 +23,18 @@ func DeleteApp(appName string) {
 	fmt.Printf("App deleted successfully: %s\n", appName)
 }
 
-func validateAppName(appName string) {
+func isAppNameValid(appName string) bool {
 	if appName == "app" {
 		fmt.Println("You can't delete the app folder, it's the example component")
-		os.Exit(0)
+		return false
 	}
 
 	if appName == "bff" {
 		fmt.Println("You can't delete the bff folder, it's required to run the application")
-		os.Exit(0)
+		return false
 	}
+
+	return true
 }
 
 func checkIfAppFolderExists(pathToDelete string) {
@@ -40,7 +44,7 @@ func checkIfAppFolderExists(pathToDelete string) {
 		} else {
 			fmt.Println("Error checking app folder: ", err)
 		}
-		panic(err)
+		panic(0)
 	}
 }
 

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -15,7 +15,7 @@ func DeleteApp(appName string) {
 	err := os.RemoveAll(appFolderPath)
 	if err != nil {
 		fmt.Println("Error deleting app folder: ", err)
-		os.Exit(1)
+		panic(err)
 	}
 
 	fmt.Printf("App deleted successfully: %s\n", appName)
@@ -40,7 +40,7 @@ func checkIfAppFolderExists(pathToDelete string) {
 		} else {
 			fmt.Println("Error checking app folder: ", err)
 		}
-		os.Exit(1)
+		panic(err)
 	}
 }
 

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+)
+
+func DeleteApp(appName string) {
+	appFolderPath := getAppFolderPath(appName)
+	checkIfAppFolderExists(appFolderPath)
+
+	// Delete the app folder
+	err := os.RemoveAll(appFolderPath)
+	if err != nil {
+		fmt.Println("Error deleting app folder: ", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("App deleted successfully: %s\n", appName)
+}
+
+func checkIfAppFolderExists(pathToDelete string) {
+	if _, err := os.Stat(pathToDelete); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("App folder not found")
+		} else {
+			fmt.Println("Error checking app folder: ", err)
+		}
+		os.Exit(1)
+	}
+}
+
+func getAppFolderPath(appName string) string {
+	return fmt.Sprintf("internal/%s", appName)
+}

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -11,12 +11,13 @@ func DeleteApp(appName string) {
 	}
 
 	appFolderPath := getAppFolderPath(appName)
-	checkIfAppFolderExists(appFolderPath)
+	if exists := folderExists(appFolderPath); !exists {
+		return
+	}
 
 	// Delete the app folder
-	err := os.RemoveAll(appFolderPath)
-	if err != nil {
-		panic("Error deleting app folder: "+ err.Error())
+	if err := os.RemoveAll(appFolderPath); err != nil {
+		panic("Error deleting app folder: " + err.Error())
 	}
 
 	fmt.Printf("App deleted successfully: %s\n", appName)
@@ -24,27 +25,28 @@ func DeleteApp(appName string) {
 
 func isAppNameValid(appName string) bool {
 	if appName == "app" {
-		fmt.Println("You can't delete the app folder, it's the example component")
+		fmt.Println("You can't delete the app folder: it's the example component")
 		return false
 	}
 
 	if appName == "bff" {
-		fmt.Println("You can't delete the bff folder, it's required to run the application")
+		fmt.Println("You can't delete the bff folder: it's required to run the application")
 		return false
 	}
 
 	return true
 }
 
-func checkIfAppFolderExists(pathToDelete string) {
+func folderExists(pathToDelete string) bool {
 	if _, err := os.Stat(pathToDelete); err != nil {
 		if os.IsNotExist(err) {
 			fmt.Println("App folder not found")
-		} else {
-			fmt.Println("Error checking app folder: ", err)
+			return false
 		}
-		panic(0)
+
+		panic("Error checking app folder: " + err.Error())
 	}
+	return true
 }
 
 func getAppFolderPath(appName string) string {

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -6,6 +6,8 @@ import (
 )
 
 func DeleteApp(appName string) {
+	validateAppName(appName)
+
 	appFolderPath := getAppFolderPath(appName)
 	checkIfAppFolderExists(appFolderPath)
 
@@ -17,6 +19,18 @@ func DeleteApp(appName string) {
 	}
 
 	fmt.Printf("App deleted successfully: %s\n", appName)
+}
+
+func validateAppName(appName string) {
+	if appName == "app" {
+		fmt.Println("You can't delete the app folder, it's the example component")
+		os.Exit(0)
+	}
+
+	if appName == "bff" {
+		fmt.Println("You can't delete the bff folder, it's required to run the application")
+		os.Exit(0)
+	}
 }
 
 func checkIfAppFolderExists(pathToDelete string) {

--- a/internal/delete_test.go
+++ b/internal/delete_test.go
@@ -1,0 +1,98 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeleteApp(t *testing.T) {
+	tmpDir := t.TempDir()
+	appName := "test-app"
+	appFolderPath := filepath.Join(tmpDir, "internal", appName)
+
+	t.Log("tmpDir: ", tmpDir)
+
+	// Create a temporary app folder
+	err := os.MkdirAll(appFolderPath, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create app folder: %v", err)
+	}
+
+	// Change the working directory to the temporary directory
+	err = os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	// Call DeleteApp
+	DeleteApp(appName)
+
+	// Verify the app folder has been deleted
+	if _, err = os.Stat(appFolderPath); !os.IsNotExist(err) {
+		t.Fatalf("App folder was not deleted")
+	}
+}
+
+func TestDeleteApp_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	appName := "test-app"
+	appFolderPath := filepath.Join(tmpDir, appName)
+
+	// Change the working directory to the temporary directory
+	err := os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	// Call DeleteApp and expect a panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Expected panic but did not occur")
+		}
+	}()
+	DeleteApp(appName)
+
+	// Verify the app folder does not exist
+	if _, err = os.Stat(appFolderPath); !os.IsNotExist(err) {
+		t.Fatalf("App folder should not exist")
+	}
+}
+
+func TestDeleteApp_ErrorDeleting(t *testing.T) {
+	tmpDir := t.TempDir()
+	appName := "test-app"
+	appFolderPath := filepath.Join(tmpDir, appName)
+
+	// Create a temporary app folder
+	err := os.Mkdir(appFolderPath, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create app folder: %v", err)
+	}
+
+	// Change the working directory to the temporary directory
+	err = os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	// Make the app folder read-only to simulate a deletion error
+	err = os.Chmod(appFolderPath, 0444)
+	if err != nil {
+		t.Fatalf("Failed to change folder permissions: %v", err)
+	}
+
+	// Call DeleteApp and expect a panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Expected panic but did not occur")
+		}
+	}()
+	DeleteApp(appName)
+
+	// Clean up by making the app folder writable again
+	err = os.Chmod(appFolderPath, 0755)
+	if err != nil {
+		t.Fatalf("Failed to change folder permissions: %v", err)
+	}
+}


### PR DESCRIPTION
#### Summary
This PR introduces a new command `delete-app` to the [`boneless`](command:_github.copilot.openSymbolFromReferences?%5B%22%22%2C%5B%7B%22uri%22%3A%7B%22scheme%22%3A%22file%22%2C%22authority%22%3A%22%22%2C%22path%22%3A%22%2FUsers%2Fdavidgaspar%2FProjects%2Fgo%2Fboneless%2Fdata%2Ftest.patch%22%2C%22query%22%3A%22%22%2C%22fragment%22%3A%22%22%7D%2C%22pos%22%3A%7B%22line%22%3A0%2C%22character%22%3A17%7D%7D%5D%2C%2296d72e6a-b414-40fb-bff7-8c09cf3044eb%22%5D "Go to definition") CLI tool, allowing users to delete an existing app. The command ensures that critical components like [`app`](command:_github.copilot.openSymbolFromReferences?%5B%22%22%2C%5B%7B%22uri%22%3A%7B%22scheme%22%3A%22file%22%2C%22authority%22%3A%22%22%2C%22path%22%3A%22%2FUsers%2Fdavidgaspar%2FProjects%2Fgo%2Fboneless%2Fdata%2Ftest.patch%22%2C%22query%22%3A%22%22%2C%22fragment%22%3A%22%22%7D%2C%22pos%22%3A%7B%22line%22%3A5%2C%22character%22%3A12%7D%7D%5D%2C%2296d72e6a-b414-40fb-bff7-8c09cf3044eb%22%5D "Go to definition") and [`bff`](command:_github.copilot.openSymbolFromReferences?%5B%22%22%2C%5B%7B%22uri%22%3A%7B%22scheme%22%3A%22file%22%2C%22authority%22%3A%22%22%2C%22path%22%3A%22%2FUsers%2Fdavidgaspar%2FProjects%2Fgo%2Fboneless%2Fdata%2Ftest.patch%22%2C%22query%22%3A%22%22%2C%22fragment%22%3A%22%22%7D%2C%22pos%22%3A%7B%22line%22%3A72%2C%22character%22%3A17%7D%7D%5D%2C%2296d72e6a-b414-40fb-bff7-8c09cf3044eb%22%5D "Go to definition") cannot be deleted.

#### Changes
1. **Command Addition in `main.go`:**
   - Added `delete-app` to the list of available commands.
   - Updated the help text to include the new `delete-app` command.
   - Implemented the `delete-app` command logic in the [`main`](command:_github.copilot.openSymbolFromReferences?%5B%22%22%2C%5B%7B%22uri%22%3A%7B%22scheme%22%3A%22file%22%2C%22authority%22%3A%22%22%2C%22path%22%3A%22%2FUsers%2Fdavidgaspar%2FProjects%2Fgo%2Fboneless%2Fdata%2Ftest.patch%22%2C%22query%22%3A%22%22%2C%22fragment%22%3A%22%22%7D%2C%22pos%22%3A%7B%22line%22%3A0%2C%22character%22%3A26%7D%7D%5D%2C%2296d72e6a-b414-40fb-bff7-8c09cf3044eb%22%5D "Go to definition") function.

2. **New File `delete.go`:**
   - Created a new file `delete.go` in the `internal` package.
   - Implemented the [`DeleteApp`] function to handle the deletion of app folders.
   - Added helper functions:
     - [`validateAppName`]: Ensures critical components cannot be deleted.
     - [`checkIfAppFolderExists`]: Checks if the app folder exists before attempting deletion.
     - [`getAppFolderPath`]: Constructs the path to the app folder based on the app name.

#### Usage
- **Command:** `boneless delete-app <app-name>`
- **Example:** `boneless delete-app my-app`

This command will delete the specified app folder if it exists and is not a critical component.

#### Testing
- Verified that the `delete-app` command correctly deletes existing app folders.
- Ensured that attempting to delete [`app`] or [`bff`] results in an appropriate error message and no deletion occurs.
- Checked that non-existent app folders produce a "not found" error message.

#### Notes
- This feature enhances the usability of the [`boneless`] CLI by providing a straightforward way to remove apps that are no longer needed.
- Future improvements could include additional validation or confirmation prompts before deletion.