### PR TITLE
refactor: enhance dependency installation logic and bump version

### DIFF
--- a/internal/intall_deps.go
+++ b/internal/intall_deps.go
@@ -5,13 +5,15 @@ import (
 )
 
 type packages struct {
-	name, pkg string
+	name string
+	pkg  string
+	args []string
 }
 
 var PackagesForInstall = []packages{
-	{"golang-migrate", "github.com/golang-migrate/migrate/v4/cmd/migrate@latest"},
-	{"sqlc", "github.com/sqlc-dev/sqlc/cmd/sqlc@latest"},
-	{"weaver", "github.com/ServiceWeaver/weaver/cmd/weaver@latest"},
+	{"golang-migrate", "github.com/golang-migrate/migrate/v4/cmd/migrate@latest", []string{"-tags", "mysql sqlite3"}},
+	{"sqlc", "github.com/sqlc-dev/sqlc/cmd/sqlc@latest", nil},
+	{"weaver", "github.com/ServiceWeaver/weaver/cmd/weaver@latest", nil},
 }
 
 func InstallDeps(name string) {
@@ -32,7 +34,7 @@ func installDeps(packages ...packages) {
 			println(p.name, "already installed!")
 			continue
 		}
-		GoInstall(p.name, p.pkg)
+		GoInstall(p.name, append(p.args, p.pkg)...)
 	}
 }
 
@@ -64,6 +66,6 @@ func UpdateDeps(name string) {
 
 func updateDeps(packages ...packages) {
 	for _, p := range packages {
-		GoInstall(p.name, p.pkg)
+		GoInstall(p.name, append(p.args, p.pkg)...)
 	}
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const Version = "v0.7.0"
+const Version = "v0.7.1"
 
 func ValidateLatestVersion() {
 	cmd := exec.Command(goCLI, "list", "-m", "github.com/renanbastos93/boneless@latest")


### PR DESCRIPTION
- Updated the `packages` struct to include an `args` field for additional Go install arguments.
- Adjusted `PackagesForInstall` to specify tags for `golang-migrate` and allow extensibility for other dependencies.
- Modified `GoInstall` calls to accommodate the new `args` field, enabling flexible command composition.
- Incremented the application version from `v0.7.0` to `v0.7.1`.